### PR TITLE
make sure empty .created response shows up in possible responses in docs

### DIFF
--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -43,6 +43,16 @@ extension AbstractRouteContext {
                         )
                     )
                 }
+                
+                // special handling for status code 201 (created)
+                if statusCode == .status(code: 201) {
+                    return (
+                        statusCode,
+                        OpenAPI.Response(
+                            description: responseReason
+                        )
+                    )
+                }
 
                 let contentType = responseTuple.contentType?.openAPIContentType
 

--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -34,18 +34,7 @@ extension AbstractRouteContext {
                 let responseReason = HTTPStatus(statusCode: responseTuple.statusCode)
                     .reasonPhrase
 
-                // special handling for status code 204 (no content)
-                if statusCode == .status(code: 204) {
-                    return (
-                        statusCode,
-                        OpenAPI.Response(
-                            description: responseReason
-                        )
-                    )
-                }
-                
-                // special handling for status code 201 (created)
-                if statusCode == .status(code: 201) {
+                if responseTuple.responseBodyType == EmptyResponseBody.self {
                     return (
                         statusCode,
                         OpenAPI.Response(

--- a/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
+++ b/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
@@ -86,6 +86,7 @@ This text supports _markdown_!
 
         let requestExample = document.paths["/hello"]?.post?.requestBody?.b?.content[.json]?.example
         XCTAssertNotNil(requestExample)
+        XCTAssertNotNil(document.paths["/hello"]?.post?.responses[.status(code: 201)])
         let requestExampleDict = requestExample?.value as? [String: Any]
         XCTAssertNotNil(requestExampleDict, "Expected request example to decode as a dictionary from String to Any")
 
@@ -165,7 +166,7 @@ struct TestCreateRouteContext: RouteContext {
 
     let success: ResponseContext<String> = .init { response in
         response.headers = Self.plainTextHeader
-        response.status = .ok
+        response.status = .created
     }
 
     let badRequest: CannedResponse<String> = .init(


### PR DESCRIPTION
Similar issue to #9 but with the `.created` status code. 