### PR TITLE
Add docs, update to async/await compatible version of VaporTypedRoutes and add async/await tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.swiftpm
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8e4d51908dd49272667126403bf977c5c503f78f",
-          "version": "1.5.0"
+          "revision": "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
+          "version": "1.11.5"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/async-kit.git",
         "state": {
           "branch": null,
-          "revision": "c1de408100a2f2e4ab2ea06512e8635bc1a59144",
-          "version": "1.3.1"
+          "revision": "c3329e444bafbb12d1d312af9191be95348a8175",
+          "version": "1.13.0"
         }
       },
       {
@@ -24,17 +24,8 @@
         "repositoryURL": "https://github.com/vapor/console-kit.git",
         "state": {
           "branch": null,
-          "revision": "cfe8bcd58f74ffecb4f536d8237de146b634ecd3",
-          "version": "4.2.6"
-        }
-      },
-      {
-        "package": "FineJSON",
-        "repositoryURL": "https://github.com/omochi/FineJSON.git",
-        "state": {
-          "branch": null,
-          "revision": "05101709243cb66d80c92e645210a3b80cf4e17f",
-          "version": "1.14.0"
+          "revision": "a7e67a1719933318b5ab7eaaed355cde020465b1",
+          "version": "4.5.0"
         }
       },
       {
@@ -42,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/multipart-kit.git",
         "state": {
           "branch": null,
-          "revision": "c9ea04017b7fb3b1f034ad7a77f8e53d3e080be5",
-          "version": "4.2.1"
+          "revision": "0d55c35e788451ee27222783c7d363cb88092fab",
+          "version": "4.5.2"
         }
       },
       {
@@ -51,8 +42,8 @@
         "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
         "state": {
           "branch": null,
-          "revision": "4986552e76c331a99770428bd2be77ad76068c08",
-          "version": "2.4.0"
+          "revision": "328d11996ccc43205bd861535021d8c22168a08a",
+          "version": "2.5.0"
         }
       },
       {
@@ -65,21 +56,12 @@
         }
       },
       {
-        "package": "RichJSONParser",
-        "repositoryURL": "https://github.com/omochi/RichJSONParser.git",
-        "state": {
-          "branch": null,
-          "revision": "263e2ecfe88d0500fa99e4cbc8c948529d335534",
-          "version": "3.0.0"
-        }
-      },
-      {
         "package": "routing-kit",
         "repositoryURL": "https://github.com/vapor/routing-kit.git",
         "state": {
           "branch": null,
-          "revision": "a0801a36a6ad501d5ad6285cbcd4774de6b0a734",
-          "version": "4.3.0"
+          "revision": "ffac7b3a127ce1e85fb232f1a6271164628809ad",
+          "version": "4.6.0"
         }
       },
       {
@@ -92,12 +74,39 @@
         }
       },
       {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "swift-backtrace",
         "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
         "state": {
           "branch": null,
-          "revision": "d3e04a9d4b3833363fb6192065b763310b156d54",
-          "version": "1.3.1"
+          "revision": "f25620d5d05e2f1ba27154b40cafea2b67566956",
+          "version": "1.3.3"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
         }
       },
       {
@@ -105,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "d9825fa541df64b1a7b182178d61b9a82730d01f",
+          "version": "2.1.0"
         }
       },
       {
@@ -114,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {
@@ -123,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "e382458581b05839a571c578e90060fff499f101",
-          "version": "2.1.1"
+          "revision": "53be78637ecd165d1ddedc4e20de69b8f43ec3b7",
+          "version": "2.3.2"
         }
       },
       {
@@ -132,8 +141,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
-          "version": "2.30.0"
+          "revision": "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
+          "version": "2.41.1"
         }
       },
       {
@@ -141,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
-          "version": "1.10.0"
+          "revision": "5334d949febb396a4e2e5235e9fbcd9c3c014bb3",
+          "version": "1.13.0"
         }
       },
       {
@@ -150,8 +159,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "13b6a7a83864005334818d7ea2a3053869a96c04",
-          "version": "1.18.0"
+          "revision": "f9ab1c94c80d568efd762d2a638f25162691d766",
+          "version": "1.22.1"
         }
       },
       {
@@ -159,8 +168,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "9db7cee4b62c39160a6bd513a47a1ecdcceac18a",
-          "version": "2.14.0"
+          "revision": "a6f9a034e5903024c6bac4ce2c56b157688d844f",
+          "version": "2.22.0"
         }
       },
       {
@@ -168,8 +177,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
-          "version": "1.11.0"
+          "revision": "4e02d9cf35cabfb538c96613272fb027dd0c8692",
+          "version": "1.13.1"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
         }
       },
       {
@@ -177,17 +195,17 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "2ada54b7ce56cc6934cd2c0207bef2305bfbd7a1",
-          "version": "4.48.2"
+          "revision": "dda0de537e7906414dccd551e77095be1e34e3da",
+          "version": "4.65.2"
         }
       },
       {
         "package": "VaporTypedRoutes",
-        "repositoryURL": "https://github.com/mattpolzin/VaporTypedRoutes.git",
+        "repositoryURL": "https://github.com/tetraoxygen/VaporTypedRoutes.git",
         "state": {
-          "branch": null,
-          "revision": "73cd29ed2c44900e9f54a09c1c336d97adc72b32",
-          "version": "0.7.1"
+          "branch": "main",
+          "revision": "0417f9effe35bbc9da24fb22dd55d3fa24df5317",
+          "version": null
         }
       },
       {
@@ -195,8 +213,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "a2d26b3de8b3be292f3208d1c74024f76ac503da",
-          "version": "2.1.3"
+          "revision": "2d9d2188a08eef4a869d368daab21b3c08510991",
+          "version": "2.6.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -204,7 +204,7 @@
         "repositoryURL": "https://github.com/tetraoxygen/VaporTypedRoutes.git",
         "state": {
           "branch": "main",
-          "revision": "0417f9effe35bbc9da24fb22dd55d3fa24df5317",
+          "revision": "f88ea049b0758c9afc9abd31d8af804dbe8079bc",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -201,11 +201,11 @@
       },
       {
         "package": "VaporTypedRoutes",
-        "repositoryURL": "https://github.com/tetraoxygen/VaporTypedRoutes.git",
+        "repositoryURL": "https://github.com/mattpolzin/VaporTypedRoutes.git",
         "state": {
-          "branch": "main",
-          "revision": "f88ea049b0758c9afc9abd31d8af804dbe8079bc",
-          "version": null
+          "branch": null,
+          "revision": "fcc305353a7289203bb2e05356913993a4b04a6d",
+          "version": "0.8.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "VaporOpenAPI",
     platforms: [
-        .macOS(.v10_15)
+		.macOS(.v12)
     ],
     products: [
         .library(
@@ -14,7 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.5.0"),
-        .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", .upToNextMinor(from: "0.7.1")),
+//        .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", .upToNextMinor(from: "0.7.1")),
+		.package(url: "https://github.com/tetraoxygen/VaporTypedRoutes.git", .branch("main")),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "VaporOpenAPI",
     platforms: [
-		.macOS(.v12)
+        .macOS(.v12)
     ],
     products: [
         .library(
@@ -14,8 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.5.0"),
-//        .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", .upToNextMinor(from: "0.7.1")),
-		.package(url: "https://github.com/tetraoxygen/VaporTypedRoutes.git", .branch("main")),
+        .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", from: "0.8.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["VaporOpenAPI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.5.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.50.0"),
         .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", from: "0.8.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0")

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See https://github.com/mattpolzin/VaporOpenAPIExample for an example of a simple
 
 You use `VaporTypedRoutes.TypedRequest` instead of `Vapor.Request` to form a request context that can be used to built out an OpenAPI description. You use custom methods to attach your routes to the app. These methods mirror the methods available in Vapor already.
 
-You can use the routes like this with Swift Concurrency:
+You can use the library like this with Swift Concurrency:
 
 ```swift
 enum WidgetController {

--- a/README.md
+++ b/README.md
@@ -6,8 +6,33 @@ See https://github.com/mattpolzin/VaporOpenAPIExample for an example of a simple
 
 You use `VaporTypedRoutes.TypedRequest` instead of `Vapor.Request` to form a request context that can be used to built out an OpenAPI description. You use custom methods to attach your routes to the app. These methods mirror the methods available in Vapor already.
 
-```swift
+You can use the routes like this with Swift Concurrency:
 
+```swift
+enum WidgetController {
+    struct ShowRoute: RouteContext {
+        ...
+    }
+    
+    static func show(_ req: TypedRequest<ShowRoute>) try await -> Response {
+        ...
+    }
+}
+
+func routes(_ app: Application) {
+    app.get(
+        "widgets",
+        ":type".description("The type of widget"),
+        ":id".parameterType(Int.self),
+        use: WidgetController.show 
+    ).tags("Widgets")
+      .summary("Get a widget")
+}
+```
+
+...and like this with a NIO EventLoopFuture:
+
+```swift
 enum WidgetController {
     struct ShowRoute: RouteContext {
         ...

--- a/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
@@ -11,10 +11,10 @@ import OpenAPIKit
 import OpenAPIReflection
 
 extension EventLoopFuture: OpenAPIEncodedSchemaType where Value: OpenAPIEncodedSchemaType {
-	/// Get the OpenAPISchema for for the value using a given encoder.
-	/// - Parameters:
-	///   - encoder: The JSONEncoder to encode the schema with.
-	/// - Returns: A JSONSchema object for the `EventLoopFuture`'s value.
+    /// Get the OpenAPISchema for for the value using a given encoder.
+    /// - Parameters:
+    ///   - encoder: The JSONEncoder to encode the schema with.
+    /// - Returns: A JSONSchema object for the `EventLoopFuture`'s value.
     public static func openAPISchema(using encoder: JSONEncoder) throws -> JSONSchema {
         return try Value.openAPISchema(using: encoder)
     }

--- a/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
@@ -11,6 +11,10 @@ import OpenAPIKit
 import OpenAPIReflection
 
 extension EventLoopFuture: OpenAPIEncodedSchemaType where Value: OpenAPIEncodedSchemaType {
+	/// Get the OpenAPISchema for for the value using a given encoder.
+	/// - Parameters:
+	///   - encoder: The JSONEncoder to encode the schema with.
+	/// - Returns: A JSONSchema object for the `EventLoopFuture`'s value.
     public static func openAPISchema(using encoder: JSONEncoder) throws -> JSONSchema {
         return try Value.openAPISchema(using: encoder)
     }

--- a/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
@@ -9,7 +9,7 @@ import OpenAPIKit
 
 /// A protocol for OpenAPI Arrays.
 protocol _Array {
-	/// The type of element in the array.
+    /// The type of element in the array.
     static var elementType: Any.Type { get }
 }
 extension Array: _Array {
@@ -28,11 +28,11 @@ extension Dictionary: _Dictionary {
 }
 
 extension AbstractQueryParam {
-	/// Get the equivalent OpenAPI parameter for the query param.
+    /// Get the equivalent OpenAPI parameter for the query param.
     public func openAPIQueryParam() -> OpenAPI.Parameter {
         let schema: OpenAPI.Parameter.SchemaContext
 
-		/// Guess the equivalent JSON Schema type for a given Swift type.
+        /// Guess the equivalent JSON Schema type for a given Swift type.
         func guessJsonSchema(for type: Any.Type) -> JSONSchema {
             guard let schemaType = type as? OpenAPISchemaType.Type else {
                     return .string

--- a/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
@@ -7,7 +7,9 @@
 
 import OpenAPIKit
 
-/// A protocol for OpenAPI Arrays.
+/// A protocol meant only for internal use.
+/// Allows generic constraints and runtime casts on arrays
+/// even though concrete arrays have an associated type.
 protocol _Array {
     /// The type of element in the array.
     static var elementType: Any.Type { get }

--- a/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
@@ -7,7 +7,9 @@
 
 import OpenAPIKit
 
+/// A protocol for OpenAPI Arrays.
 protocol _Array {
+	/// The type of element in the array.
     static var elementType: Any.Type { get }
 }
 extension Array: _Array {
@@ -26,9 +28,11 @@ extension Dictionary: _Dictionary {
 }
 
 extension AbstractQueryParam {
+	/// Get the equivalent OpenAPI parameter for the query param.
     public func openAPIQueryParam() -> OpenAPI.Parameter {
         let schema: OpenAPI.Parameter.SchemaContext
 
+		/// Guess the equivalent JSON Schema type for a given Swift type.
         func guessJsonSchema(for type: Any.Type) -> JSONSchema {
             guard let schemaType = type as? OpenAPISchemaType.Type else {
                     return .string

--- a/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
+++ b/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
@@ -10,16 +10,20 @@ import OpenAPIKit
 import OpenAPIReflection
 import Sampleable
 
+/// Types that provide an example for the OpenAPI definition.
 public protocol OpenAPIExampleProvider: OpenAPIEncodedSchemaType {
+	/// The example for the OpenAPI schema.
     static func openAPIExample(using encoder: JSONEncoder) throws -> AnyCodable?
 }
 
 extension OpenAPIExampleProvider where Self: Encodable, Self: Sampleable {
+	// Automatically implement the OpenAPI example for types conforming to Encodable and Sampleable.
     public static func openAPIExample(using encoder: JSONEncoder) throws -> AnyCodable? {
         let encodedSelf = try encoder.encode(sample)
         return try JSONDecoder().decode(AnyCodable.self, from: encodedSelf)
     }
 
+	/// Get the OpenAPI schema for the `OpenAPIExampleProvider`.
     public static func openAPISchema(using encoder: JSONEncoder) throws -> JSONSchema {
         return try genericOpenAPISchemaGuess(using: encoder)
     }

--- a/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
+++ b/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
@@ -12,18 +12,18 @@ import Sampleable
 
 /// Types that provide an example for the OpenAPI definition.
 public protocol OpenAPIExampleProvider: OpenAPIEncodedSchemaType {
-	/// The example for the OpenAPI schema.
+    /// The example for the OpenAPI schema.
     static func openAPIExample(using encoder: JSONEncoder) throws -> AnyCodable?
 }
 
 extension OpenAPIExampleProvider where Self: Encodable, Self: Sampleable {
-	// Automatically implement the OpenAPI example for types conforming to Encodable and Sampleable.
+    // Automatically implement the OpenAPI example for types conforming to Encodable and Sampleable.
     public static func openAPIExample(using encoder: JSONEncoder) throws -> AnyCodable? {
         let encodedSelf = try encoder.encode(sample)
         return try JSONDecoder().decode(AnyCodable.self, from: encodedSelf)
     }
 
-	/// Get the OpenAPI schema for the `OpenAPIExampleProvider`.
+    /// Get the OpenAPI schema for the `OpenAPIExampleProvider`.
     public static func openAPISchema(using encoder: JSONEncoder) throws -> JSONSchema {
         return try genericOpenAPISchemaGuess(using: encoder)
     }

--- a/Sources/VaporOpenAPI/VaporHttp+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporHttp+OpenAPI.swift
@@ -9,7 +9,7 @@ import Vapor
 import OpenAPIKit
 
 extension HTTPMethod {
-	/// The equivalent OpenAPI verb for the `HTTPMethod`.
+    /// The equivalent OpenAPI verb for the `HTTPMethod`.
     internal func openAPIVerb() throws -> OpenAPI.HttpMethod {
         switch self {
         case .GET:
@@ -33,14 +33,14 @@ extension HTTPMethod {
         }
     }
 
-	/// Errors that can be thrown when attempting to convert from `HTTPMethod` to OpenAPI's equivalent.
+    /// Errors that can be thrown when attempting to convert from `HTTPMethod` to OpenAPI's equivalent.
     enum OpenAPIHTTPMethodError: Swift.Error {
         case unsupportedHttpMethod(String)
     }
 }
 
 extension HTTPMediaType {
-	/// The equivalent OpenAPI `ContentType` for the `HTTPMediaType`.
+    /// The equivalent OpenAPI `ContentType` for the `HTTPMediaType`.
     public var openAPIContentType: OpenAPI.ContentType? {
         return OpenAPI.ContentType(rawValue: "\(self.type)/\(self.subType)")
     }

--- a/Sources/VaporOpenAPI/VaporHttp+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporHttp+OpenAPI.swift
@@ -9,6 +9,7 @@ import Vapor
 import OpenAPIKit
 
 extension HTTPMethod {
+	/// The equivalent OpenAPI verb for the `HTTPMethod`.
     internal func openAPIVerb() throws -> OpenAPI.HttpMethod {
         switch self {
         case .GET:
@@ -32,12 +33,14 @@ extension HTTPMethod {
         }
     }
 
+	/// Errors that can be thrown when attempting to convert from `HTTPMethod` to OpenAPI's equivalent.
     enum OpenAPIHTTPMethodError: Swift.Error {
         case unsupportedHttpMethod(String)
     }
 }
 
 extension HTTPMediaType {
+	/// The equivalent OpenAPI `ContentType` for the `HTTPMediaType`.
     public var openAPIContentType: OpenAPI.ContentType? {
         return OpenAPI.ContentType(rawValue: "\(self.type)/\(self.subType)")
     }

--- a/Sources/VaporOpenAPI/VaporPathComponent+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporPathComponent+OpenAPI.swift
@@ -10,7 +10,7 @@ import VaporTypedRoutes
 import OpenAPIKit
 
 extension Vapor.PathComponent {
-	/// The OpenAPI equivalent of the path component's name.
+    /// The OpenAPI equivalent of the path component's name.
     internal func openAPIPathComponent() throws -> String {
         switch self {
         case .constant(let val):
@@ -23,7 +23,7 @@ extension Vapor.PathComponent {
         }
     }
 
-	/// The OpenAPI equivalent of the path parameter (including a type, if specified).
+    /// The OpenAPI equivalent of the path parameter (including a type, if specified).
     internal func openAPIPathParameter(in route: Vapor.Route) -> OpenAPI.Parameter? {
         switch self {
         case .parameter(let name):
@@ -40,7 +40,7 @@ extension Vapor.PathComponent {
         }
     }
 
-	/// Errors that can arise with the conversion from Vapor path component to the OpenAPI equivalent.
+    /// Errors that can arise with the conversion from Vapor path component to the OpenAPI equivalent.
     enum OpenAPIPathComponentError: Swift.Error {
         case unsupportedPathComponent(String)
     }

--- a/Sources/VaporOpenAPI/VaporPathComponent+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporPathComponent+OpenAPI.swift
@@ -10,6 +10,7 @@ import VaporTypedRoutes
 import OpenAPIKit
 
 extension Vapor.PathComponent {
+	/// The OpenAPI equivalent of the path component's name.
     internal func openAPIPathComponent() throws -> String {
         switch self {
         case .constant(let val):
@@ -22,6 +23,7 @@ extension Vapor.PathComponent {
         }
     }
 
+	/// The OpenAPI equivalent of the path parameter (including a type, if specified).
     internal func openAPIPathParameter(in route: Vapor.Route) -> OpenAPI.Parameter? {
         switch self {
         case .parameter(let name):
@@ -38,6 +40,7 @@ extension Vapor.PathComponent {
         }
     }
 
+	/// Errors that can arise with the conversion from Vapor path component to the OpenAPI equivalent.
     enum OpenAPIPathComponentError: Swift.Error {
         case unsupportedPathComponent(String)
     }

--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -13,7 +13,7 @@ import Sampleable
 
 /// Types that contain wrapped values (for OpenAPI conversion).
 protocol _Wrapper {
-	/// The wrapped type.
+    /// The wrapped type.
     static var wrappedType: Any.Type { get }
 }
 
@@ -24,10 +24,10 @@ extension Optional: _Wrapper {
 }
 
 extension AbstractRouteContext {
-	/// The OpenAPI equivalents of any responses in the route context.
-	/// - Parameters:
-	///  - encoder: The JSON encoder to use to generate the responses.
-	/// - Returns: A `Response.Map` containing the converted responses.
+    /// The OpenAPI equivalents of any responses in the route context.
+    /// - Parameters:
+    ///  - encoder: The JSON encoder to use to generate the responses.
+    /// - Returns: A `Response.Map` containing the converted responses.
     public static func openAPIResponses(using encoder: JSONEncoder) throws -> OpenAPI.Response.Map {
         let responseTuples = try responseBodyTuples
             .compactMap { responseTuple -> (OpenAPI.Response.StatusCode, OpenAPI.Response)? in
@@ -110,9 +110,9 @@ extension AbstractRouteContext {
 }
 
 extension Vapor.Route {
-	/// Generates the constructor for an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
-	/// - Parameters:
-	///   - encoder: The JSON encoder to generate the `PathOperationConstructor` with.
+    /// Generates the constructor for an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
+    /// - Parameters:
+    ///   - encoder: The JSON encoder to generate the `PathOperationConstructor` with.
     func openAPIPathOperationConstructor(using encoder: JSONEncoder) throws -> PathOperationConstructor {
         let pathComponents = try OpenAPI.Path(
             path.map { try $0.openAPIPathComponent() }
@@ -152,9 +152,9 @@ extension Vapor.Route {
         }
     }
 
-	/// Generates an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
-	/// - Parameters:
-	///   - encoder: The JSON encoder to generate the `PathOperation` with.
+    /// Generates an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
+    /// - Parameters:
+    ///   - encoder: The JSON encoder to generate the `PathOperation` with.
     func openAPIPathOperation(using encoder: JSONEncoder) throws -> PathOperation {
         let operation = try openAPIPathOperationConstructor(using: encoder)
 
@@ -171,9 +171,9 @@ extension Vapor.Route {
         )
     }
 
-	/// Generates an array of OpenAPI parameters equivalent to the query params in the given response's body type.
-	/// - Parameters:
-	///   - responseType: The type of response to get the query parameters from. Must be an `AbstractRouteContext` to extract query parameters.
+    /// Generates an array of OpenAPI parameters equivalent to the query params in the given response's body type.
+    /// - Parameters:
+    ///   - responseType: The type of response to get the query parameters from. Must be an `AbstractRouteContext` to extract query parameters.
     private func openAPIQueryParams(from responseType: Any.Type) -> [OpenAPI.Parameter] {
         if let responseBodyType = responseType as? AbstractRouteContext.Type {
             return responseBodyType
@@ -184,10 +184,10 @@ extension Vapor.Route {
         return []
     }
 
-	/// Generates the equivalent OpenAPI request for a given request type.
-	/// - Parameters:
-	///   - requestType: The request body type to convert.
-	///   - encoder: The JSON encoder to generate the OpenAPI request with.
+    /// Generates the equivalent OpenAPI request for a given request type.
+    /// - Parameters:
+    ///   - requestType: The request body type to convert.
+    ///   - encoder: The JSON encoder to generate the OpenAPI request with.
     private func openAPIRequest(for requestType: Any.Type, using encoder: JSONEncoder) throws -> OpenAPI.Request? {
         guard !(requestType is EmptyRequestBody.Type) else {
             return nil
@@ -211,10 +211,10 @@ extension Vapor.Route {
         )
     }
 
-	/// Generates the equivalent OpenAPI request for a given request type.
-	/// - Parameters:
-	///   - responseType: The response type to convert. If it conforms to `AbstractRouteContext`, this function will use all included responses.
-	///   - encoder: The JSON encoder to generate the OpenAPI response map with.
+    /// Generates the equivalent OpenAPI request for a given request type.
+    /// - Parameters:
+    ///   - responseType: The response type to convert. If it conforms to `AbstractRouteContext`, this function will use all included responses.
+    ///   - encoder: The JSON encoder to generate the OpenAPI response map with.
     private func openAPIResponses(from responseType: Any.Type, using encoder: JSONEncoder) throws -> OpenAPI.Response.Map {
         if let responseBodyType = responseType as? AbstractRouteContext.Type {
             return try responseBodyType.openAPIResponses(using: encoder)

--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -11,7 +11,9 @@ import OpenAPIReflection
 import Vapor
 import Sampleable
 
+/// Types that contain wrapped values (for OpenAPI conversion).
 protocol _Wrapper {
+	/// The wrapped type.
     static var wrappedType: Any.Type { get }
 }
 
@@ -22,8 +24,11 @@ extension Optional: _Wrapper {
 }
 
 extension AbstractRouteContext {
+	/// The OpenAPI equivalents of any responses in the route context.
+	/// - Parameters:
+	///  - encoder: The JSON encoder to use to generate the responses.
+	/// - Returns: A `Response.Map` containing the converted responses.
     public static func openAPIResponses(using encoder: JSONEncoder) throws -> OpenAPI.Response.Map {
-
         let responseTuples = try responseBodyTuples
             .compactMap { responseTuple -> (OpenAPI.Response.StatusCode, OpenAPI.Response)? in
 
@@ -105,7 +110,9 @@ extension AbstractRouteContext {
 }
 
 extension Vapor.Route {
-
+	/// Generates the constructor for an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
+	/// - Parameters:
+	///   - encoder: The JSON encoder to generate the `PathOperationConstructor` with.
     func openAPIPathOperationConstructor(using encoder: JSONEncoder) throws -> PathOperationConstructor {
         let pathComponents = try OpenAPI.Path(
             path.map { try $0.openAPIPathComponent() }
@@ -145,7 +152,10 @@ extension Vapor.Route {
         }
     }
 
-    func openAPIPathOperation(using encoder: JSONEncoder) throws -> (path: OpenAPI.Path, verb: OpenAPI.HttpMethod, operation: OpenAPI.Operation) {
+	/// Generates an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
+	/// - Parameters:
+	///   - encoder: The JSON encoder to generate the `PathOperation` with.
+    func openAPIPathOperation(using encoder: JSONEncoder) throws -> PathOperation {
         let operation = try openAPIPathOperationConstructor(using: encoder)
 
         let summary = userInfo["openapi:summary"] as? String
@@ -161,6 +171,9 @@ extension Vapor.Route {
         )
     }
 
+	/// Generates an array of OpenAPI parameters equivalent to the query params in the given response's body type.
+	/// - Parameters:
+	///   - responseType: The type of response to get the query parameters from. Must be an `AbstractRouteContext` to extract query parameters.
     private func openAPIQueryParams(from responseType: Any.Type) -> [OpenAPI.Parameter] {
         if let responseBodyType = responseType as? AbstractRouteContext.Type {
             return responseBodyType
@@ -171,6 +184,10 @@ extension Vapor.Route {
         return []
     }
 
+	/// Generates the equivalent OpenAPI request for a given request type.
+	/// - Parameters:
+	///   - requestType: The request body type to convert.
+	///   - encoder: The JSON encoder to generate the OpenAPI request with.
     private func openAPIRequest(for requestType: Any.Type, using encoder: JSONEncoder) throws -> OpenAPI.Request? {
         guard !(requestType is EmptyRequestBody.Type) else {
             return nil
@@ -194,8 +211,11 @@ extension Vapor.Route {
         )
     }
 
+	/// Generates the equivalent OpenAPI request for a given request type.
+	/// - Parameters:
+	///   - responseType: The response type to convert. If it conforms to `AbstractRouteContext`, this function will use all included responses.
+	///   - encoder: The JSON encoder to generate the OpenAPI response map with.
     private func openAPIResponses(from responseType: Any.Type, using encoder: JSONEncoder) throws -> OpenAPI.Response.Map {
-
         if let responseBodyType = responseType as? AbstractRouteContext.Type {
             return try responseBodyType.openAPIResponses(using: encoder)
         }
@@ -226,6 +246,10 @@ extension Vapor.Route {
     }
 }
 
+/// Generates an example from a given type.
+/// - Parameters:
+///   - typeToSample: The type to generate a sample from. If it doesn't conform to `OpenAPIExampleProvider`, an example can't be generated.
+///   - encoder: The JSON encoder to generate the example with.
 private func reverseEngineeredExample(for typeToSample: Any.Type, using encoder: JSONEncoder) -> AnyCodable? {
     guard let exampleType = typeToSample as? OpenAPIExampleProvider.Type else {
         return nil
@@ -234,10 +258,19 @@ private func reverseEngineeredExample(for typeToSample: Any.Type, using encoder:
     return try? exampleType.openAPIExample(using: encoder)
 }
 
+/// The context for an OpenAPI path operation.
+/// - Parameters:
+///   - summary: The summary of the path operation, if any.
+///   - description: The longer description of the path operation, if any,
+///   - tags: Any tags the path operation can have.
 typealias PartialPathOperationContext = (
     summary: String?,
     description: String?,
     tags: [String]?
 )
 
-typealias PathOperationConstructor = (PartialPathOperationContext) -> (path: OpenAPI.Path, verb: OpenAPI.HttpMethod, operation: OpenAPI.Operation)
+/// A function that takes a `PartialPathOperationContext` and returns a `PathOperation`.
+typealias PathOperationConstructor = (PartialPathOperationContext) -> PathOperation
+
+/// A tuple containing a path, verb, and operation.
+typealias PathOperation = (path: OpenAPI.Path, verb: OpenAPI.HttpMethod, operation: OpenAPI.Operation)

--- a/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
@@ -10,6 +10,9 @@ import OpenAPIKit
 import Vapor
 
 extension Vapor.Routes {
+	/// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
+	/// - Parameters:
+	///   - encoder: The JSON encoder to generate the OpenAPI path item map with.
     public func openAPIPathItems(using encoder: JSONEncoder) throws -> OpenAPI.PathItem.Map {
         let operations = try all
             .map { try $0.openAPIPathOperation(using: encoder) }

--- a/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
@@ -10,9 +10,9 @@ import OpenAPIKit
 import Vapor
 
 extension Vapor.Routes {
-	/// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
-	/// - Parameters:
-	///   - encoder: The JSON encoder to generate the OpenAPI path item map with.
+    /// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
+    /// - Parameters:
+    ///   - encoder: The JSON encoder to generate the OpenAPI path item map with.
     public func openAPIPathItems(using encoder: JSONEncoder) throws -> OpenAPI.PathItem.Map {
         let operations = try all
             .map { try $0.openAPIPathOperation(using: encoder) }

--- a/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
+++ b/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
@@ -9,7 +9,7 @@ final class VaporOpenAPITests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.get("hello", use: TestController.indexRoute)
+		app.get("hello", use: TestController.indexRoute)
         app.post("hello", use: TestController.createRoute)
         app.get(
             "hello",
@@ -19,79 +19,105 @@ final class VaporOpenAPITests: XCTestCase {
         app.delete("hello", use: TestController.deleteRoute)
         app.post("hello", "empty", use: TestController.createEmptyReturn)
 
-        // TODO: Add support for ContentEncoder to JSONAPIOpenAPI
-        let jsonEncoder = JSONEncoder()
-        if #available(macOS 10.12, *) {
-            jsonEncoder.dateEncodingStrategy = .iso8601
-            jsonEncoder.outputFormatting = .sortedKeys
-        }
-        #if os(Linux)
-        jsonEncoder.dateEncodingStrategy = .iso8601
-        jsonEncoder.outputFormatting = .sortedKeys
-        #endif
+        try testRoutes(on: app)
+    }
 
-        let info = OpenAPI.Document.Info(
-            title: "Vapor OpenAPI Test API",
-            description:
+	func testAsyncExample() throws {
+		let app = Application(.testing)
+		defer { app.shutdown() }
+
+		let route = app.get("hello", use: AsyncTestController.indexRoute)
+		app.post("hello", use: AsyncTestController.createRoute)
+		app.get(
+			"hello",
+			":id".parameterType(Int.self).description("hello world"),
+			use: AsyncTestController.showRoute
+		)
+		app.delete("hello", use: AsyncTestController.deleteRoute)
+		app.post("hello", "empty", use: AsyncTestController.createEmptyReturn)
+
+		try testRoutes(on: app)
+	}
+
+	/// Just the route-checking bits in their own function so we can test out EventLoopFuture handling and async/await cleanly.
+	func testRoutes(on app: Application) throws {
+		// TODO: Add support for ContentEncoder to JSONAPIOpenAPI
+		let jsonEncoder = JSONEncoder()
+		if #available(macOS 10.12, *) {
+			jsonEncoder.dateEncodingStrategy = .iso8601
+			jsonEncoder.outputFormatting = .sortedKeys
+		}
+#if os(Linux)
+		jsonEncoder.dateEncodingStrategy = .iso8601
+		jsonEncoder.outputFormatting = .sortedKeys
+#endif
+
+		let info = OpenAPI.Document.Info(
+			title: "Vapor OpenAPI Test API",
+			description:
 """
 ## Descriptive Text
 This text supports _markdown_!
 """,
-            version: "1.0"
-        )
+			version: "1.0"
+		)
 
-        // TODO: get hostname & port from environment
-        let servers = [
-            OpenAPI.Server(url: URL(string: "http://localhost")!)
-        ]
+		// TODO: get hostname & port from environment
+		let servers = [
+			OpenAPI.Server(url: URL(string: "http://localhost")!)
+		]
 
-        let components = OpenAPI.Components(
-            schemas: [:],
-            responses: [:],
-            parameters: [:],
-            examples: [:],
-            requestBodies: [:],
-            headers: [:]
-        )
+		let components = OpenAPI.Components(
+			schemas: [:],
+			responses: [:],
+			parameters: [:],
+			examples: [:],
+			requestBodies: [:],
+			headers: [:]
+		)
 
-        let paths = try app.routes.openAPIPathItems(using: jsonEncoder)
+		let paths = try app.routes.openAPIPathItems(using: jsonEncoder)
 
-        let document = OpenAPI.Document(
-            info: info,
-            servers: servers,
-            paths: paths,
-            components: components,
-            security: []
-        )
+		let document = OpenAPI.Document(
+			info: info,
+			servers: servers,
+			paths: paths,
+			components: components,
+			security: []
+		)
 
-        XCTAssertEqual(document.paths.count, 3)
-        XCTAssertNotNil(document.paths["/hello"]?.get)
-        XCTAssertNotNil(document.paths["/hello"]?.post)
-        XCTAssertNotNil(document.paths["/hello"]?.delete)
-        XCTAssertNil(document.paths["/hello"]?.put)
-        XCTAssertNil(document.paths["/hello"]?.patch)
-        XCTAssertNil(document.paths["/hello"]?.head)
-        XCTAssertNil(document.paths["/hello"]?.options)
-        XCTAssertNil(document.paths["/hello"]?.trace)
-        XCTAssertNotNil(document.paths["/hello/{id}"]?.get)
+		XCTAssertEqual(document.paths.count, 3)
+		XCTAssertNotNil(document.paths["/hello"]?.get)
+		XCTAssertNotNil(document.paths["/hello"]?.post)
+		XCTAssertNotNil(document.paths["/hello"]?.delete)
+		XCTAssertNil(document.paths["/hello"]?.put)
+		XCTAssertNil(document.paths["/hello"]?.patch)
+		XCTAssertNil(document.paths["/hello"]?.head)
+		XCTAssertNil(document.paths["/hello"]?.options)
+		XCTAssertNil(document.paths["/hello"]?.trace)
+		XCTAssertNotNil(document.paths["/hello/{id}"]?.get)
 
-        XCTAssertNotNil(document.paths["/hello"]?.get?.responses[.status(code: 200)])
-        XCTAssertNotNil(document.paths["/hello"]?.get?.responses[.status(code: 400)])
-        XCTAssertNotNil(document.paths["/hello"]?.delete?.responses[.status(code: 204)])
-        
-        XCTAssertNotNil(document.paths["/hello/empty"]?.post?.responses[.status(code: 201)])
+		let problematicPath = document.paths["/hello"]!
+		let problematicOperation = problematicPath.get!
+		let problematicResponses = problematicOperation.responses
 
-        XCTAssertEqual(document.paths["/hello/{id}"]?.get?.parameters[0].parameterValue?.description, "hello world")
-        XCTAssertEqual(document.paths["/hello/{id}"]?.get?.parameters[0].parameterValue?.schemaOrContent.schemaValue, .integer)
+		XCTAssertNotNil(document.paths["/hello"]?.get?.responses[.status(code: 200)])
+		XCTAssertNotNil(document.paths["/hello"]?.get?.responses[.status(code: 400)])
+		XCTAssertNotNil(document.paths["/hello"]?.delete?.responses[.status(code: 204)])
 
-        let requestExample = document.paths["/hello"]?.post?.requestBody?.b?.content[.json]?.example
-        XCTAssertNotNil(requestExample)
-        XCTAssertNotNil(document.paths["/hello"]?.post?.responses[.status(code: 201)])
-        let requestExampleDict = requestExample?.value as? [String: Any]
-        XCTAssertNotNil(requestExampleDict, "Expected request example to decode as a dictionary from String to Any")
+		XCTAssertNotNil(document.paths["/hello/empty"]?.post?.responses[.status(code: 201)])
 
-        XCTAssertEqual(requestExampleDict?["stringValue"] as? String, "hello world!")
-    }
+		XCTAssertEqual(document.paths["/hello/{id}"]?.get?.parameters[0].parameterValue?.description, "hello world")
+		XCTAssertEqual(document.paths["/hello/{id}"]?.get?.parameters[0].parameterValue?.schemaOrContent.schemaValue, .integer)
+
+		let requestExample = document.paths["/hello"]?.post?.requestBody?.b?.content[.json]?.example
+		XCTAssertNotNil(requestExample)
+		XCTAssertNotNil(document.paths["/hello"]?.post?.responses[.status(code: 201)])
+		let requestExampleDict = requestExample?.value as? [String: Any]
+		XCTAssertNotNil(requestExampleDict, "Expected request example to decode as a dictionary from String to Any")
+
+		XCTAssertEqual(requestExampleDict?["stringValue"] as? String, "hello world!")
+	}
 }
 
 struct CreatableResource: Codable, Sampleable, OpenAPIExampleProvider {
@@ -238,4 +264,38 @@ final class TestController {
     static func createEmptyReturn(_ req: TypedRequest<TestCreateEmptyReturnRouteContext>) -> EventLoopFuture<Response> {
         return req.response.success.encodeEmptyResponse()
     }
+}
+
+final class AsyncTestController {
+	static func indexRoute(_ req: TypedRequest<TestIndexRouteContext>) async throws -> Response {
+		if let text = req.query.echo {
+			return try await req.response.success.encode("\(text)")
+		}
+		return try await req.response.success.encode("Hello")
+	}
+
+	static func showRoute(_ req: TypedRequest<TestShowRouteContext>) async throws -> Response {
+		if req.query.badQuery != nil {
+			return try await req.response.get(\.badRequest)
+		}
+		if let text = req.query.echo {
+			return try await req.response.success.encode("\(text)")
+		}
+		return try await req.response.success.encode("Hello")
+	}
+
+	static func createRoute(_ req: TypedRequest<TestCreateRouteContext>) async throws -> Response {
+		if req.query.badQuery != nil {
+			return try await req.response.get(\.badRequest)
+		}
+		return try await req.response.success.encode("Hello")
+	}
+
+	static func deleteRoute(_ req: TypedRequest<TestDeleteRouteContext>) async throws -> Response {
+		return try await req.response.success.encodeEmptyResponse()
+	}
+
+	static func createEmptyReturn(_ req: TypedRequest<TestCreateEmptyReturnRouteContext>) async throws -> Response {
+		return try await req.response.success.encodeEmptyResponse()
+	}
 }


### PR DESCRIPTION
Docs and tests for async/await are currently in this PR, but the async/await version is currently mapped to my fork, pending this PR to VaporTypedRoutes: https://github.com/mattpolzin/VaporTypedRoutes/pull/3