### PR TITLE
Add support for JSON ContentEncoder to the OpenAPI JSON encoder requiring types.

### DIFF
--- a/Sources/VaporOpenAPI/ContentConfiguration+JSONEncoder.swift
+++ b/Sources/VaporOpenAPI/ContentConfiguration+JSONEncoder.swift
@@ -21,4 +21,13 @@ extension ContentConfiguration {
 
         return encoder
     }
+
+    /// The content JSON encoder, but with the settings to encode an OpenAPI schema.
+    func openAPIJSONEncoder() throws -> JSONEncoder {
+        let encoder = try self.jsonEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .sortedKeys
+
+        return encoder
+    }
 }

--- a/Sources/VaporOpenAPI/ContentConfiguration+JSONEncoder.swift
+++ b/Sources/VaporOpenAPI/ContentConfiguration+JSONEncoder.swift
@@ -1,0 +1,24 @@
+//
+//  ContentConfiguration+JSONEncoder.swift
+//  
+//
+//  Created by Charlie Welsh on 9/16/22.
+//
+
+import Vapor
+
+extension ContentConfiguration {
+    /// The configured JSON encoder for the content configuration.
+    func jsonEncoder() throws -> JSONEncoder {
+        guard let encoder = try self
+            .requireEncoder(for: .json)
+                as? JSONEncoder
+        else {
+            // This is an Abort since this is an error with a Vapor component.
+            throw Abort(
+                .internalServerError, reason: "Couldn't get encoder for OpenAPI schema.")
+        }
+
+        return encoder
+    }
+}

--- a/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
@@ -23,7 +23,7 @@ extension EventLoopFuture: OpenAPIEncodedSchemaType where Value: OpenAPIEncodedS
     /// Get the OpenAPISchema for for the value using the ContentConfiguration.
     /// - Returns: A JSONSchema object for the `EventLoopFuture`'s value.
     public static func openAPISchema() throws -> JSONSchema {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPISchema(using: encoder)
     }

--- a/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/EventLoopFuture+OpenAPI.swift
@@ -9,6 +9,7 @@ import Foundation
 import NIO
 import OpenAPIKit
 import OpenAPIReflection
+import Vapor
 
 extension EventLoopFuture: OpenAPIEncodedSchemaType where Value: OpenAPIEncodedSchemaType {
     /// Get the OpenAPISchema for for the value using a given encoder.
@@ -17,5 +18,13 @@ extension EventLoopFuture: OpenAPIEncodedSchemaType where Value: OpenAPIEncodedS
     /// - Returns: A JSONSchema object for the `EventLoopFuture`'s value.
     public static func openAPISchema(using encoder: JSONEncoder) throws -> JSONSchema {
         return try Value.openAPISchema(using: encoder)
+    }
+
+    /// Get the OpenAPISchema for for the value using the ContentConfiguration.
+    /// - Returns: A JSONSchema object for the `EventLoopFuture`'s value.
+    public static func openAPISchema() throws -> JSONSchema {
+        let encoder = try ContentConfiguration.global.jsonEncoder()
+
+        return try self.openAPISchema(using: encoder)
     }
 }

--- a/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
+++ b/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
@@ -9,6 +9,7 @@ import Foundation
 import OpenAPIKit
 import OpenAPIReflection
 import Sampleable
+import Vapor
 
 /// Types that provide an example for the OpenAPI definition.
 public protocol OpenAPIExampleProvider: OpenAPIEncodedSchemaType {
@@ -19,10 +20,24 @@ public protocol OpenAPIExampleProvider: OpenAPIEncodedSchemaType {
 }
 
 extension OpenAPIExampleProvider where Self: Encodable, Self: Sampleable {
+    /// The example for the OpenAPI schema.
+    public static func openAPIExample() throws -> AnyCodable? {
+        let encoder = try ContentConfiguration.global.jsonEncoder()
+
+        return try self.openAPIExample(using: encoder)
+    }
+
     // Automatically implement the OpenAPI example for types conforming to Encodable and Sampleable.
     public static func openAPIExample(using encoder: JSONEncoder) throws -> AnyCodable? {
         let encodedSelf = try encoder.encode(sample)
         return try JSONDecoder().decode(AnyCodable.self, from: encodedSelf)
+    }
+
+    /// Get the OpenAPI schema for the `OpenAPIExampleProvider`.
+    public static func openAPISchema() throws -> JSONSchema {
+        let encoder = try ContentConfiguration.global.jsonEncoder()
+
+        return try self.openAPISchema(using: encoder)
     }
 
     /// Get the OpenAPI schema for the `OpenAPIExampleProvider`.

--- a/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
+++ b/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
@@ -22,7 +22,7 @@ public protocol OpenAPIExampleProvider: OpenAPIEncodedSchemaType {
 extension OpenAPIExampleProvider where Self: Encodable, Self: Sampleable {
     /// The example for the OpenAPI schema.
     public static func openAPIExample() throws -> AnyCodable? {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIExample(using: encoder)
     }
@@ -35,7 +35,7 @@ extension OpenAPIExampleProvider where Self: Encodable, Self: Sampleable {
 
     /// Get the OpenAPI schema for the `OpenAPIExampleProvider`.
     public static func openAPISchema() throws -> JSONSchema {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPISchema(using: encoder)
     }

--- a/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
+++ b/Sources/VaporOpenAPI/Sampleable+OpenAPIExample.swift
@@ -13,6 +13,8 @@ import Sampleable
 /// Types that provide an example for the OpenAPI definition.
 public protocol OpenAPIExampleProvider: OpenAPIEncodedSchemaType {
     /// The example for the OpenAPI schema.
+    /// - Parameters:
+    ///   - encoder: The encoder to use to generate the OpenAPI example with.
     static func openAPIExample(using encoder: JSONEncoder) throws -> AnyCodable?
 }
 

--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -154,8 +154,18 @@ extension Vapor.Route {
 
     /// Generates an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
     /// - Parameters:
-    ///   - encoder: The JSON encoder to generate the `PathOperation` with.
-    func openAPIPathOperation(using encoder: JSONEncoder) throws -> PathOperation {
+    ///   - encoder: An optional override JSON encoder to generate the `PathOperation` with. Otherwise, defaults to the ContentEncoder.
+    func openAPIPathOperation(using encoder: JSONEncoder? = nil) throws -> PathOperation {
+        guard
+            let encoder = try encoder ?? ContentConfiguration
+                .global
+                .requireEncoder(for: .json)
+                as? JSONEncoder
+        else {
+            // This is an Abort since this is an error with Vapor.
+            throw Abort(.internalServerError, reason: "Couldn't get encoder for OpenAPI schema.")
+        }
+
         let operation = try openAPIPathOperationConstructor(using: encoder)
 
         let summary = userInfo["openapi:summary"] as? String

--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -27,7 +27,7 @@ extension AbstractRouteContext {
     /// The OpenAPI equivalents of any responses in the route context.
     /// - Returns: A `Response.Map` containing the converted responses.
     public static func openAPIResponses() throws -> OpenAPI.Response.Map {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIResponses(using: encoder)
     }
@@ -120,7 +120,7 @@ extension AbstractRouteContext {
 extension Vapor.Route {
     /// Generates the constructor for an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
     func openAPIPathOperationConstructor() throws -> PathOperationConstructor {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIPathOperationConstructor(using: encoder)
     }
@@ -169,7 +169,7 @@ extension Vapor.Route {
 
     /// Generates an OpenAPI `PathOperation` equivalent to the Vapor `Route`.
     func openAPIPathOperation() throws -> PathOperation {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIPathOperation(using: encoder)
     }
@@ -210,7 +210,7 @@ extension Vapor.Route {
     /// - Parameters:
     ///   - requestType: The request body type to convert.
     func openAPIRequest(for requestType: Any.Type) throws -> OpenAPI.Request? {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIRequest(for: requestType, using: encoder)
     }
@@ -246,7 +246,7 @@ extension Vapor.Route {
     /// - Parameters:
     ///   - responseType: The response type to convert. If it conforms to `AbstractRouteContext`, this function will use all included responses.
     private func openAPIResponses(from responseType: Any.Type) throws -> OpenAPI.Response.Map {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIResponses(from: responseType, using: encoder)
     }

--- a/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
@@ -11,9 +11,16 @@ import Vapor
 
 extension Vapor.Routes {
     /// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
+    public func openAPIPathItems() throws -> OpenAPI.PathItem.Map {
+        let encoder = try ContentConfiguration.global.jsonEncoder()
+
+        return try self.openAPIPathItems(using: encoder)
+    }
+
+    /// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
     /// - Parameters:
-    ///   - encoder: An optional override JSON encoder to generate the OpenAPI path item map with. Defaults to the ContentEncoder for JSON.
-    public func openAPIPathItems(using encoder: JSONEncoder? = nil) throws -> OpenAPI.PathItem.Map {
+    ///   - encoder: The `JSONEncoder` to generate the OpenAPI path item map with.
+    public func openAPIPathItems(using encoder: JSONEncoder) throws -> OpenAPI.PathItem.Map {
         let operations = try all
             .map { try $0.openAPIPathOperation(using: encoder) }
 

--- a/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
@@ -12,8 +12,8 @@ import Vapor
 extension Vapor.Routes {
     /// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
     /// - Parameters:
-    ///   - encoder: The JSON encoder to generate the OpenAPI path item map with.
-    public func openAPIPathItems(using encoder: JSONEncoder) throws -> OpenAPI.PathItem.Map {
+    ///   - encoder: An optional override JSON encoder to generate the OpenAPI path item map with. Defaults to the ContentEncoder for JSON.
+    public func openAPIPathItems(using encoder: JSONEncoder? = nil) throws -> OpenAPI.PathItem.Map {
         let operations = try all
             .map { try $0.openAPIPathOperation(using: encoder) }
 

--- a/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoutes+OpenAPI.swift
@@ -12,7 +12,7 @@ import Vapor
 extension Vapor.Routes {
     /// Generates the equivalent OpenAPI `PathItem` map for the Vapor Routes.
     public func openAPIPathItems() throws -> OpenAPI.PathItem.Map {
-        let encoder = try ContentConfiguration.global.jsonEncoder()
+        let encoder = try ContentConfiguration.global.openAPIJSONEncoder()
 
         return try self.openAPIPathItems(using: encoder)
     }

--- a/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
+++ b/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
@@ -26,7 +26,7 @@ final class VaporOpenAPITests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let route = app.get("hello", use: AsyncTestController.indexRoute)
+        app.get("hello", use: AsyncTestController.indexRoute)
         app.post("hello", use: AsyncTestController.createRoute)
         app.get(
             "hello",
@@ -85,10 +85,6 @@ This text supports _markdown_!
         XCTAssertNil(document.paths["/hello"]?.options)
         XCTAssertNil(document.paths["/hello"]?.trace)
         XCTAssertNotNil(document.paths["/hello/{id}"]?.get)
-
-        let problematicPath = document.paths["/hello"]!
-        let problematicOperation = problematicPath.get!
-        let problematicResponses = problematicOperation.responses
 
         XCTAssertNotNil(document.paths["/hello"]?.get?.responses[.status(code: 200)])
         XCTAssertNotNil(document.paths["/hello"]?.get?.responses[.status(code: 400)])

--- a/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
+++ b/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
@@ -41,17 +41,6 @@ final class VaporOpenAPITests: XCTestCase {
 
     /// Just the route-checking bits in their own function so we can test out EventLoopFuture handling and async/await cleanly.
     func testRoutes(on app: Application) throws {
-        // TODO: Add support for ContentEncoder to JSONAPIOpenAPI
-        let jsonEncoder = JSONEncoder()
-        if #available(macOS 10.12, *) {
-            jsonEncoder.dateEncodingStrategy = .iso8601
-            jsonEncoder.outputFormatting = .sortedKeys
-        }
-#if os(Linux)
-        jsonEncoder.dateEncodingStrategy = .iso8601
-        jsonEncoder.outputFormatting = .sortedKeys
-#endif
-
         let info = OpenAPI.Document.Info(
             title: "Vapor OpenAPI Test API",
             description:
@@ -76,7 +65,7 @@ This text supports _markdown_!
             headers: [:]
         )
 
-        let paths = try app.routes.openAPIPathItems(using: jsonEncoder)
+        let paths = try app.routes.openAPIPathItems()
 
         let document = OpenAPI.Document(
             info: info,

--- a/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
+++ b/Tests/VaporOpenAPITests/VaporOpenAPITests.swift
@@ -51,9 +51,10 @@ This text supports _markdown_!
             version: "1.0"
         )
 
-        // TODO: get hostname & port from environment
+        let portString = "\(app.http.server.configuration.port == 80 ? "" : ":\(app.http.server.configuration.port)")"
+
         let servers = [
-            OpenAPI.Server(url: URL(string: "http://localhost")!)
+            OpenAPI.Server(url: URL(string: "http://\(app.http.server.configuration.hostname)\(portString)")!)
         ]
 
         let components = OpenAPI.Components(


### PR DESCRIPTION
This should solve that `// TODO` in the tests.