### PR TITLE
Implement required and deprecated in QueryParam

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -201,11 +201,11 @@
       },
       {
         "package": "VaporTypedRoutes",
-        "repositoryURL": "https://github.com/TimAEllis/VaporTypedRoutes.git",
+        "repositoryURL": "https://github.com/mattpolzin/VaporTypedRoutes.git",
         "state": {
-          "branch": "main",
-          "revision": "a242f07c708e613bf43a2707aae46f60b551f04c",
-          "version": null
+          "branch": null,
+          "revision": "e8015627a2def1b641ceba9d605972a40eeff309",
+          "version": "0.9.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -201,11 +201,11 @@
       },
       {
         "package": "VaporTypedRoutes",
-        "repositoryURL": "https://github.com/mattpolzin/VaporTypedRoutes.git",
+        "repositoryURL": "https://github.com/TimAEllis/VaporTypedRoutes.git",
         "state": {
-          "branch": null,
-          "revision": "fcc305353a7289203bb2e05356913993a4b04a6d",
-          "version": "0.8.0"
+          "branch": "main",
+          "revision": "a242f07c708e613bf43a2707aae46f60b551f04c",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.50.0"),
-        .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", from: "0.8.0"),
+        .package(url: "https://github.com/TimAEllis/VaporTypedRoutes.git", .branch("main")),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.50.0"),
-        .package(url: "https://github.com/TimAEllis/VaporTypedRoutes.git", .branch("main")),
+        .package(url: "https://github.com/mattpolzin/VaporTypedRoutes.git", from: "0.9.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0")
     ],

--- a/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/QueryParam+OpenAPI.swift
@@ -37,7 +37,7 @@ extension AbstractQueryParam {
         /// Guess the equivalent JSON Schema type for a given Swift type.
         func guessJsonSchema(for type: Any.Type) -> JSONSchema {
             guard let schemaType = type as? OpenAPISchemaType.Type else {
-                    return .string
+                return .string
             }
             let ret = schemaType.openAPISchema
             guard let allowedValues = self.allowedValues else {
@@ -77,9 +77,10 @@ extension AbstractQueryParam {
 
         return .init(
             name: name,
-            context: .query,
+            context: .query(required: `required`),
             schema: schema,
-            description: description
+            description: description,
+            deprecated: deprecated
         )
     }
 }


### PR DESCRIPTION
This simply adds the `required` and `deprecated` properties to the generated `OpenAPI.Parameter`.

TODO:
- [x] Typed routes PR needs merging -  https://github.com/mattpolzin/VaporTypedRoutes/pull/5
- [x] New version of [VaporTypedRoutes](https://github.com/mattpolzin/VaporTypedRoutes) needs to be released
- [x] Restore `Package.swift` to point to https://github.com/mattpolzin/VaporTypedRoutes.git, pointing to the new version.