### PR TITLE
Add support for marking routes as deprecated

### DIFF
--- a/Sources/VaporOpenAPI/Route+Metadata.swift
+++ b/Sources/VaporOpenAPI/Route+Metadata.swift
@@ -39,4 +39,11 @@ extension Route {
         userInfo["openapi:tags"] = tags
         return self
     }
+    
+    /// Add OpenAPI-compatible deprecation notice to the route.
+    @discardableResult
+    public func deprecated() -> Route {
+        userInfo["openapi:deprecated"] = true
+        return self
+    }
 }

--- a/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
+++ b/Sources/VaporOpenAPI/VaporRoute+OpenAPI.swift
@@ -156,6 +156,7 @@ extension Vapor.Route {
                 parameters: parameters.map { .init($0) },
                 requestBody: requestBody,
                 responses: responses,
+                deprecated: context.deprecated,
                 servers: nil
             )
 
@@ -183,12 +184,14 @@ extension Vapor.Route {
         let summary = userInfo["openapi:summary"] as? String
         let description = userInfo["description"] as? String
         let tags = userInfo["openapi:tags"] as? [String]
+        let deprecated = userInfo["openapi:deprecated"] as? Bool ?? false
 
         return operation(
             (
                 summary: summary,
                 description: description,
-                tags: tags
+                tags: tags,
+                deprecated: deprecated
             )
         )
     }
@@ -301,12 +304,14 @@ private func reverseEngineeredExample(for typeToSample: Any.Type, using encoder:
 /// The context for an OpenAPI path operation.
 /// - Parameters:
 ///   - summary: The summary of the path operation, if any.
-///   - description: The longer description of the path operation, if any,
+///   - description: The longer description of the path operation, if any.
 ///   - tags: Any tags the path operation can have.
+///   - deprecated: If `true`, then it marks the path operation as deprecated.
 typealias PartialPathOperationContext = (
     summary: String?,
     description: String?,
-    tags: [String]?
+    tags: [String]?,
+    deprecated: Bool
 )
 
 /// A function that takes a `PartialPathOperationContext` and returns a `PathOperation`.


### PR DESCRIPTION
This adds an extra meta function to the `Route` class to allow end users to easily mark a route as deprecated.

Usage example:
```swift
let authGroup = routes.grouped("auth")
authGroup.post("login", use: login)
    .tags("Auth")
// legacy route marked as deprecated
authGroup.post("legacyLogin", use: legacyLogin)
    .tags("Auth")
    .deprecated()
```

Let me know what you think and if you think it will be a useful addition :)